### PR TITLE
Rename the main source file and the main module; also, fix the test suite (by changing `ClusterManagers` to `LSFClusterManagers`)

### DIFF
--- a/src/LSFClusterManager.jl
+++ b/src/LSFClusterManager.jl
@@ -1,4 +1,4 @@
-module ClusterManagers
+module LSFClusterManager
 
 using Distributed
 using Sockets
@@ -21,4 +21,4 @@ include("affinity.jl")
 include("elastic.jl")
 include("lsf.jl")
 
-end
+end # module

--- a/test/elastic.jl
+++ b/test/elastic.jl
@@ -4,7 +4,7 @@
     em = ElasticManager(addr=:auto, port=0)
 
     # launch worker
-    run(`sh -c $(ClusterManagers.get_connect_cmd(em))`, wait=false)
+    run(`sh -c $(LSFClusterManager.get_connect_cmd(em))`, wait=false)
 
     # wait at most TIMEOUT seconds for it to connect
     @test :ok == timedwait(TIMEOUT) do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-import ClusterManagers
+import LSFClusterManager
 import Test
 
 import Distributed

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,13 +10,13 @@ using Distributed: procs, nprocs
 using Distributed: remotecall_fetch, @spawnat
 using Test: @testset, @test, @test_skip
 # ElasticManager:
-using ClusterManagers: ElasticManager
+using LSFClusterManager: ElasticManager
 # Slurm:
-using ClusterManagers: addprocs_slurm, SlurmManager
+using LSFClusterManager: addprocs_slurm, SlurmManager
 # LSF:
-using ClusterManagers: addprocs_lsf, LSFManager
+using LSFClusterManager: addprocs_lsf, LSFManager
 # SGE:
-using ClusterManagers: addprocs_sge, SGEManager
+using LSFClusterManager: addprocs_sge, SGEManager
 
 const test_args = lowercase.(strip.(ARGS))
 


### PR DESCRIPTION
1. Rename `src/ClusterManagers.jl` to `src/LSFClusterManager.jl`.
2. Rename the `ClusterManagers` module to `LSFClusterManager`.
3. Fix a test (change import ClusterManagers to `import LSFClusterManager`)
4. Fix tests (change `using ClusterManagers` to `using LSFClusterManager`)
5. Fix a test (change `ClusterManagers.` to `LSFClusterManager.`)

Targets `dpa/project-toml` (#1).