### PR TITLE
Simplify the way that the LSF tests are launched

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,23 +13,12 @@ using Test: @testset, @test, @test_skip
 # LSF:
 using LSFClusterManager: addprocs_lsf, LSFManager
 
-const test_args = lowercase.(strip.(ARGS))
-
-@info "" test_args
-
 lsf_is_installed() = !isnothing(Sys.which("bsub"))
 
 @testset "LSFClusterManager.jl" begin
-    if lsf_is_installed()
-        @info "Running the LSF tests..." Sys.which("bsub")
-        include("lsf.jl")
-    else
-        if "lsf" in test_args
-            @error "ERROR: The LSF tests were explicitly requested in ARGS, but bsub was not found, so the LSF tests cannot be run" Sys.which("bsub") test_args
-            @test false
-        else
-            @warn "bsub was not found - LSF tests will be skipped" Sys.which("bsub")
-            @test_skip false
-        end
-    end
-end # @testset
+    @info "" Sys.which("bsub")
+
+    @test lsf_is_installed()
+
+    include("lsf.jl")
+end


### PR DESCRIPTION
Partially addresses @bjarthur's comment here: https://github.com/JuliaParallel/LSFClusterManager.jl/issues/10#issuecomment-2622747111