### PR TITLE
Disable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,31 +12,30 @@ concurrency:
 permissions:
   contents: read
 jobs:
-  no-ci:
+  finalize:
     timeout-minutes: 10
-    if: false
+    needs:
+      - no-ci
+    # Important: the next line MUST be `if: always()`.
+    # Do not change that line.
+    # That line is necessary to make sure that this job runs even if tests fail.
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "Currently we do not have any CI for this repo. https://github.com/JuliaParallel/LSFClusterManager.jl/issues/6"
-  # finalize:
-  #   timeout-minutes: 10
-  #   needs:
-  #     - unit-tests
-  #   # Important: the next line MUST be `if: always()`.
-  #   # Do not change that line.
-  #   # That line is necessary to make sure that this job runs even if tests fail.
-  #   if: always()
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - run: |
-  #         echo unit-tests: ${{ needs.unit-tests.result }}
-  #     - run: exit 1
-  #       # The last line must NOT end with ||
-  #       # All other lines MUST end with ||
-  #       if: |
-  #         (needs.unit-tests.result != 'success')
-  # unit-tests:
+          echo no-ci: ${{ needs.no-ci.result }}
+      - run: exit 1
+        # The last line must NOT end with ||
+        # All other lines MUST end with ||
+        if: |
+          (needs.no-ci.result != 'success')
+  no-ci:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::warning Currently we do not have any CI for this repo. https://github.com/JuliaParallel/LSFClusterManager.jl/issues/6"
+  # tests:
   #   runs-on: ubuntu-latest
   #   timeout-minutes: 20
   #   strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "Currently we do not have any CI for this repo."
+          echo "Currently we do not have any CI for this repo. https://github.com/JuliaParallel/LSFClusterManager.jl/issues/6"
   # finalize:
   #   timeout-minutes: 10
   #   needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "::warning Currently we do not have any CI for this repo. https://github.com/JuliaParallel/LSFClusterManager.jl/issues/6"
+          echo "::warning ::Currently we do not have any CI for this repo. https://github.com/JuliaParallel/LSFClusterManager.jl/issues/6"
   # tests:
   #   runs-on: ubuntu-latest
   #   timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
     timeout-minutes: 10
     if: false
     runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Currently we do not have any CI for this repo."
   # finalize:
   #   timeout-minutes: 10
   #   needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,39 +12,43 @@ concurrency:
 permissions:
   contents: read
 jobs:
-  finalize:
+  no-ci:
     timeout-minutes: 10
-    needs:
-      - unit-tests
-    # Important: the next line MUST be `if: always()`.
-    # Do not change that line.
-    # That line is necessary to make sure that this job runs even if tests fail.
-    if: always()
+    if: false
     runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo unit-tests: ${{ needs.unit-tests.result }}
-      - run: exit 1
-        # The last line must NOT end with ||
-        # All other lines MUST end with ||
-        if: |
-          (needs.unit-tests.result != 'success')
-  unit-tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - '1.2'  # minimum Julia version supported in Project.toml
-          - '1.6'  # previous LTS
-          - '1.10' # current LTS
-          - '1'    # automatically expands to the latest stable 1.x release of Julia
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-    - uses: julia-actions/setup-julia@v2
-      with:
-        version: ${{ matrix.version }}
-    - uses: julia-actions/julia-runtest@v1
+  # finalize:
+  #   timeout-minutes: 10
+  #   needs:
+  #     - unit-tests
+  #   # Important: the next line MUST be `if: always()`.
+  #   # Do not change that line.
+  #   # That line is necessary to make sure that this job runs even if tests fail.
+  #   if: always()
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - run: |
+  #         echo unit-tests: ${{ needs.unit-tests.result }}
+  #     - run: exit 1
+  #       # The last line must NOT end with ||
+  #       # All other lines MUST end with ||
+  #       if: |
+  #         (needs.unit-tests.result != 'success')
+  # unit-tests:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 20
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       version:
+  #         - '1.2'  # minimum Julia version supported in Project.toml
+  #         - '1.6'  # previous LTS
+  #         - '1.10' # current LTS
+  #         - '1'    # automatically expands to the latest stable 1.x release of Julia
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #     with:
+  #       persist-credentials: false
+  #   - uses: julia-actions/setup-julia@v2
+  #     with:
+  #       version: ${{ matrix.version }}
+  #   - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
We don't currently have a way of installing LSF in CI.

Cross-ref: #6.

So, for now, there is no benefit from trying to run `Pkg.test()` in CI. And a bunch of red ❌'s will likely confuse users even more.